### PR TITLE
Fix case-insensitive search in uppercase directory

### DIFF
--- a/fnd.go
+++ b/fnd.go
@@ -113,6 +113,7 @@ func parseDir(options map[string]string, directory string, stdout io.Writer) {
 			printIfMached(options, directory, filename, stdout)
 		}
 		if fileinfo.IsDir() {
+			filename := fileinfo.Name()
 			parseDir(options, filepath.Join(directory, filename),
 				stdout)
 		}


### PR DESCRIPTION
Directory names weren't reset to their original form before entering them.
